### PR TITLE
Fix typo in translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -5722,7 +5722,7 @@ msgstr "Master-Archiv ist fehlerhaft konfiguriert"
 
 #: libpurple/protocols/novell/nmuser.c:1913
 msgid "Incorrect username or password"
-msgstr "Benutzername oder Passwort ungülzig"
+msgstr "Benutzername oder Passwort ungültig"
 
 #: libpurple/protocols/novell/nmuser.c:1916
 msgid "Could not recognize the host of the username you entered"


### PR DESCRIPTION
The word "ungültig" was misspelled